### PR TITLE
feat: add CAMB AI TTS provider support

### DIFF
--- a/src/core/CambAITTS/index.ts
+++ b/src/core/CambAITTS/index.ts
@@ -1,0 +1,83 @@
+import urlJoin from 'url-join';
+
+import { CAMBAI_BASE_URL } from '@/core/const/api';
+import { arrayBufferConvert } from '@/core/utils/arrayBufferConvert';
+
+import voiceList, { getCambAIVoiceOptions } from './voiceList';
+
+export type CambAISpeechModel = 'mars-flash' | 'mars-pro' | 'mars-instruct';
+export type CambAIOutputFormat = 'mp3' | 'wav' | 'raw';
+
+export interface CambAITTSPayload {
+  input: string;
+  options: {
+    format?: CambAIOutputFormat;
+    language: string;
+    speech_model?: CambAISpeechModel;
+    voice_id: number;
+  };
+}
+
+export interface CambAITTSAPI {
+  CAMBAI_API_KEY?: string;
+  CAMBAI_PROXY_URL?: string;
+  headers?: Headers;
+  serviceUrl?: string;
+}
+
+export class CambAITTS {
+  private CAMBAI_BASE_URL: string;
+  private CAMBAI_API_KEY: string | undefined;
+  private serviceUrl: string | undefined;
+  private headers?: Headers;
+
+  constructor(api: CambAITTSAPI = {}) {
+    this.CAMBAI_BASE_URL = api.CAMBAI_PROXY_URL || CAMBAI_BASE_URL;
+    this.CAMBAI_API_KEY = api.CAMBAI_API_KEY;
+    this.serviceUrl = api.serviceUrl;
+    this.headers = api.headers;
+  }
+
+  get voiceOptions() {
+    return getCambAIVoiceOptions();
+  }
+
+  static voiceList = voiceList;
+
+  fetch = async (payload: CambAITTSPayload) => {
+    const url = urlJoin(this.CAMBAI_BASE_URL, 'tts-stream');
+    return this.serviceUrl
+      ? fetch(this.serviceUrl, {
+          body: JSON.stringify(payload),
+          headers: this.headers,
+          method: 'POST',
+        })
+      : fetch(url, {
+          body: JSON.stringify({
+            language: payload.options.language || 'en-us',
+            output_configuration: { format: payload.options.format || 'mp3' },
+            speech_model: payload.options.speech_model || 'mars-flash',
+            text: payload.input,
+            voice_id: payload.options.voice_id,
+          }),
+          headers: new Headers({
+            'Content-Type': 'application/json',
+            'x-api-key': this.CAMBAI_API_KEY || '',
+          }),
+          method: 'POST',
+        });
+  };
+
+  create = async (payload: CambAITTSPayload): Promise<Response> => {
+    const response = await this.fetch(payload);
+
+    return response;
+  };
+
+  createAudio = async (payload: CambAITTSPayload): Promise<AudioBuffer> => {
+    const response = await this.create(payload);
+
+    const arrayBuffer = await response.arrayBuffer();
+    return await arrayBufferConvert(arrayBuffer);
+  };
+}

--- a/src/core/CambAITTS/voiceList.ts
+++ b/src/core/CambAITTS/voiceList.ts
@@ -1,0 +1,27 @@
+import type { SelectProps } from 'antd';
+
+export interface CambAIVoice {
+  id: number;
+  language: string;
+  name: string;
+}
+
+const voiceList: CambAIVoice[] = [
+  { id: 147_320, language: 'en-us', name: 'Attic' },
+  { id: 147_321, language: 'en-us', name: 'Celeste' },
+  { id: 147_322, language: 'en-us', name: 'Elm' },
+  { id: 147_323, language: 'en-us', name: 'Fern' },
+  { id: 147_324, language: 'en-us', name: 'Haze' },
+  { id: 147_325, language: 'en-us', name: 'Ivy' },
+  { id: 147_326, language: 'en-us', name: 'Jade' },
+  { id: 147_327, language: 'en-us', name: 'Luna' },
+  { id: 147_328, language: 'en-us', name: 'Maple' },
+  { id: 147_329, language: 'en-us', name: 'Nova' },
+  { id: 147_330, language: 'en-us', name: 'Onyx' },
+  { id: 147_331, language: 'en-us', name: 'Pearl' },
+];
+export default voiceList;
+
+export const getCambAIVoiceOptions = (): SelectProps['options'] => {
+  return voiceList.map((voice) => ({ label: voice.name, value: voice.id }));
+};

--- a/src/core/const/api.ts
+++ b/src/core/const/api.ts
@@ -3,3 +3,5 @@ export const OPENAI_TTS_API = '/api/openai-tts';
 export const OPENAI_STT_API = '/api/openai-stt';
 export const EDGE_SPEECH_API = '/api/edge-speech';
 export const MICROSOFT_SPEECH_API = '/api/microsoft-speech';
+export const CAMBAI_BASE_URL = 'https://client.camb.ai/apis';
+export const CAMBAI_TTS_API = '/api/cambai-tts';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,10 @@
+export {
+  type CambAIOutputFormat,
+  type CambAISpeechModel,
+  CambAITTS,
+  type CambAITTSAPI,
+  type CambAITTSPayload,
+} from '@/core/CambAITTS';
 export { type EdgeSpeechAPI, type EdgeSpeechPayload, EdgeSpeechTTS } from '@/core/EdgeSpeechTTS';
 export {
   type MicrosoftSpeechAPI,

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -5,6 +5,7 @@ export { useAudioVisualizer } from './hooks/useAudioVisualizer';
 export { useBlobUrl } from './hooks/useBlobUrl';
 export { useStreamAudioPlayer } from './hooks/useStreamAudioPlayer';
 export { useAudioRecorder } from './useAudioRecorder';
+export { type CambAITTSOptions, useCambAITTS } from './useCambAITTS';
 export { type EdgeSpeechOptions, useEdgeSpeech } from './useEdgeSpeech';
 export { type MicrosoftSpeechOptions, useMicrosoftSpeech } from './useMicrosoftSpeech';
 export { type OpenAISTTOptions, useOpenAISTT } from './useOpenAISTT';

--- a/src/react/useCambAITTS/index.ts
+++ b/src/react/useCambAITTS/index.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+import { CambAITTS, type CambAITTSAPI, type CambAITTSPayload } from '@/core/CambAITTS';
+import { type TTSOptions, useTTS } from '@/react/useTTS';
+
+export interface CambAITTSOptions extends Pick<CambAITTSPayload, 'options'>, TTSOptions {
+  api?: CambAITTSAPI;
+}
+
+export const useCambAITTS = (defaultText: string, init: CambAITTSOptions) => {
+  const [text, setText] = useState<string>(defaultText);
+  const { options, api, ...swrConfig } = init;
+  const [response, setResponse] = useState<Response>();
+  const rest = useTTS(
+    String(options.voice_id),
+    text,
+    async (segmentText: string) => {
+      const instance = new CambAITTS(api);
+      const res = await instance.create({ input: segmentText, options });
+      setResponse(res);
+      return res.arrayBuffer();
+    },
+    swrConfig,
+  );
+  return {
+    response,
+    setText,
+    ...rest,
+  };
+};

--- a/src/server/createCambAIAudioSpeech.ts
+++ b/src/server/createCambAIAudioSpeech.ts
@@ -1,0 +1,30 @@
+import type { CambAITTSPayload } from '../core/CambAITTS';
+
+export interface CreateCambAIAudioSpeechOptions {
+  apiKey: string;
+  baseUrl?: string;
+  payload: CambAITTSPayload;
+}
+
+export const createCambAIAudioSpeech = async ({
+  payload,
+  apiKey,
+  baseUrl = 'https://client.camb.ai/apis',
+}: CreateCambAIAudioSpeechOptions): Promise<Response> => {
+  const { options, input } = payload;
+
+  return fetch(`${baseUrl}/tts-stream`, {
+    body: JSON.stringify({
+      language: options.language || 'en-us',
+      output_configuration: { format: options.format || 'mp3' },
+      speech_model: options.speech_model || 'mars-flash',
+      text: input,
+      voice_id: options.voice_id,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+    },
+    method: 'POST',
+  });
+};

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,8 @@
 export {
+  createCambAIAudioSpeech,
+  type CreateCambAIAudioSpeechOptions,
+} from './createCambAIAudioSpeech';
+export {
   createOpenaiAudioSpeech,
   type CreateOpenaiAudioSpeechCompletionOptions,
 } from './createOpenaiAudioSpeech';

--- a/tests/CambAITTS.test.ts
+++ b/tests/CambAITTS.test.ts
@@ -1,0 +1,326 @@
+import { CambAITTS, type CambAITTSPayload } from '@/core/CambAITTS';
+import voiceList, { getCambAIVoiceOptions } from '@/core/CambAITTS/voiceList';
+import { CAMBAI_BASE_URL } from '@/core/const/api';
+import { createCambAIAudioSpeech } from '@/server/createCambAIAudioSpeech';
+
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+const mockResponse = (body = 'audio-data', status = 200) =>
+  new Response(body, { status, headers: { 'Content-Type': 'audio/mpeg' } });
+
+const defaultPayload: CambAITTSPayload = {
+  input: 'Hello world',
+  options: {
+    language: 'en-us',
+    voice_id: 147_320,
+  },
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(mockResponse());
+});
+
+// ─── Constructor ─────────────────────────────────────────────────────
+
+describe('CambAITTS constructor', () => {
+  it('uses default CAMBAI_BASE_URL when no proxy is provided', async () => {
+    const tts = new CambAITTS();
+    await tts.fetch(defaultPayload);
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain(CAMBAI_BASE_URL);
+  });
+
+  it('uses custom CAMBAI_PROXY_URL when provided', async () => {
+    const tts = new CambAITTS({ CAMBAI_PROXY_URL: 'https://proxy.example.com' });
+    await tts.fetch(defaultPayload);
+
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('https://proxy.example.com');
+  });
+
+  it('passes API key in x-api-key header', async () => {
+    const tts = new CambAITTS({ CAMBAI_API_KEY: 'test-key-123' });
+    await tts.fetch(defaultPayload);
+
+    const headers: Headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers.get('x-api-key')).toBe('test-key-123');
+  });
+
+  it('sends empty x-api-key when no key provided', async () => {
+    const tts = new CambAITTS();
+    await tts.fetch(defaultPayload);
+
+    const headers: Headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers.get('x-api-key')).toBe('');
+  });
+});
+
+// ─── Voice list and options ──────────────────────────────────────────
+
+describe('Voice list and options', () => {
+  it('has 12 voices in CambAITTS.voiceList', () => {
+    expect(CambAITTS.voiceList).toHaveLength(12);
+  });
+
+  it('each voice has id (number), language (string), and name (string)', () => {
+    for (const voice of voiceList) {
+      expect(typeof voice.id).toBe('number');
+      expect(typeof voice.language).toBe('string');
+      expect(typeof voice.name).toBe('string');
+    }
+  });
+
+  it('includes known voices Attic=147320 and Pearl=147331', () => {
+    const attic = voiceList.find((v) => v.name === 'Attic');
+    const pearl = voiceList.find((v) => v.name === 'Pearl');
+
+    expect(attic).toBeDefined();
+    expect(attic!.id).toBe(147_320);
+    expect(pearl).toBeDefined();
+    expect(pearl!.id).toBe(147_331);
+  });
+
+  it('voiceOptions returns { label, value } arrays', () => {
+    const tts = new CambAITTS();
+    const options = tts.voiceOptions;
+
+    expect(options).toHaveLength(12);
+    for (const opt of options!) {
+      expect(opt).toHaveProperty('label');
+      expect(opt).toHaveProperty('value');
+    }
+  });
+
+  it('first option maps to { label: "Attic", value: 147320 }', () => {
+    const options = getCambAIVoiceOptions();
+
+    expect(options![0]).toEqual({ label: 'Attic', value: 147_320 });
+  });
+});
+
+// ─── fetch() – direct API call ───────────────────────────────────────
+
+describe('fetch() - direct API call', () => {
+  let tts: CambAITTS;
+
+  beforeEach(() => {
+    tts = new CambAITTS({ CAMBAI_API_KEY: 'key-abc' });
+  });
+
+  it('POSTs to correct URL', async () => {
+    await tts.fetch(defaultPayload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${CAMBAI_BASE_URL}/tts-stream`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('sends correct headers', async () => {
+    await tts.fetch(defaultPayload);
+
+    const headers: Headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect(headers.get('x-api-key')).toBe('key-abc');
+  });
+
+  it('sends correct body', async () => {
+    await tts.fetch(defaultPayload);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({
+      language: 'en-us',
+      output_configuration: { format: 'mp3' },
+      speech_model: 'mars-flash',
+      text: 'Hello world',
+      voice_id: 147_320,
+    });
+  });
+
+  it('defaults speech_model to mars-flash', async () => {
+    await tts.fetch(defaultPayload);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.speech_model).toBe('mars-flash');
+  });
+
+  it('defaults language to en-us on falsy value', async () => {
+    const payload: CambAITTSPayload = {
+      input: 'test',
+      options: { language: '', voice_id: 147_320 },
+    };
+    await tts.fetch(payload);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.language).toBe('en-us');
+  });
+
+  it('uses custom speech_model when provided', async () => {
+    const payload: CambAITTSPayload = {
+      input: 'test',
+      options: { language: 'en-us', speech_model: 'mars-pro', voice_id: 147_320 },
+    };
+    await tts.fetch(payload);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.speech_model).toBe('mars-pro');
+  });
+
+  it('defaults format to mp3', async () => {
+    await tts.fetch(defaultPayload);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.output_configuration.format).toBe('mp3');
+  });
+
+  it('uses custom format when provided', async () => {
+    const payload: CambAITTSPayload = {
+      input: 'test',
+      options: { format: 'wav', language: 'en-us', voice_id: 147_320 },
+    };
+    await tts.fetch(payload);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.output_configuration.format).toBe('wav');
+  });
+
+  it('returns a Response', async () => {
+    const result = await tts.fetch(defaultPayload);
+    expect(result).toBeInstanceOf(Response);
+  });
+});
+
+// ─── fetch() – serviceUrl routing ────────────────────────────────────
+
+describe('fetch() - serviceUrl routing', () => {
+  it('POSTs to serviceUrl instead of base URL', async () => {
+    const tts = new CambAITTS({ serviceUrl: 'https://my-service.com/tts' });
+    await tts.fetch(defaultPayload);
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://my-service.com/tts');
+  });
+
+  it('sends raw payload (not transformed) as body', async () => {
+    const tts = new CambAITTS({ serviceUrl: 'https://my-service.com/tts' });
+    await tts.fetch(defaultPayload);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual(defaultPayload);
+  });
+
+  it('uses custom headers', async () => {
+    const customHeaders = new Headers({ Authorization: 'Bearer token' });
+    const tts = new CambAITTS({
+      headers: customHeaders,
+      serviceUrl: 'https://my-service.com/tts',
+    });
+    await tts.fetch(defaultPayload);
+
+    const headers: Headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers.get('Authorization')).toBe('Bearer token');
+  });
+
+  it('does not include x-api-key', async () => {
+    const tts = new CambAITTS({
+      CAMBAI_API_KEY: 'should-not-appear',
+      serviceUrl: 'https://my-service.com/tts',
+    });
+    await tts.fetch(defaultPayload);
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    // serviceUrl path passes this.headers (undefined), not a new Headers with api key
+    expect(headers).toBeUndefined();
+  });
+});
+
+// ─── create() ────────────────────────────────────────────────────────
+
+describe('create()', () => {
+  it('returns the Response from fetch', async () => {
+    const tts = new CambAITTS({ CAMBAI_API_KEY: 'key' });
+    const response = await tts.create(defaultPayload);
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(200);
+  });
+
+  it('propagates fetch errors', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('Network failure'));
+    const tts = new CambAITTS({ CAMBAI_API_KEY: 'key' });
+
+    await expect(tts.create(defaultPayload)).rejects.toThrow('Network failure');
+  });
+});
+
+// ─── createCambAIAudioSpeech server helper ───────────────────────────
+
+describe('createCambAIAudioSpeech server helper', () => {
+  it('POSTs to default baseUrl + /tts-stream', async () => {
+    await createCambAIAudioSpeech({ apiKey: 'srv-key', payload: defaultPayload });
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://client.camb.ai/apis/tts-stream');
+  });
+
+  it('POSTs to custom baseUrl + /tts-stream', async () => {
+    await createCambAIAudioSpeech({
+      apiKey: 'srv-key',
+      baseUrl: 'https://custom.api.com',
+      payload: defaultPayload,
+    });
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://custom.api.com/tts-stream');
+  });
+
+  it('sends correct headers as plain object with x-api-key', async () => {
+    await createCambAIAudioSpeech({ apiKey: 'srv-key', payload: defaultPayload });
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers).toEqual({
+      'Content-Type': 'application/json',
+      'x-api-key': 'srv-key',
+    });
+  });
+
+  it('sends correct body structure', async () => {
+    await createCambAIAudioSpeech({ apiKey: 'srv-key', payload: defaultPayload });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({
+      language: 'en-us',
+      output_configuration: { format: 'mp3' },
+      speech_model: 'mars-flash',
+      text: 'Hello world',
+      voice_id: 147_320,
+    });
+  });
+
+  it('applies defaults for language and speech_model', async () => {
+    const payload: CambAITTSPayload = {
+      input: 'test',
+      options: { language: '', voice_id: 147_320 },
+    };
+    await createCambAIAudioSpeech({ apiKey: 'srv-key', payload });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.language).toBe('en-us');
+    expect(body.speech_model).toBe('mars-flash');
+  });
+
+  it('uses custom format when provided', async () => {
+    const payload: CambAITTSPayload = {
+      input: 'test',
+      options: { format: 'wav', language: 'en-us', voice_id: 147_320 },
+    };
+    await createCambAIAudioSpeech({ apiKey: 'srv-key', payload });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.output_configuration.format).toBe('wav');
+  });
+});
+
+// ─── createAudio (skipped – requires AudioContext) ───────────────────
+
+describe.todo('createAudio() - requires AudioContext.decodeAudioData (not in jsdom)');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 import { name } from './package.json';
@@ -5,8 +6,8 @@ import { name } from './package.json';
 export default defineConfig({
   test: {
     alias: {
-      '@': './src',
-      [name]: './src',
+      '@': resolve(__dirname, './src'),
+      [name]: resolve(__dirname, './src'),
     },
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- Add `CambAITTS` class with direct API and proxy/serviceUrl routing
- Add `useCambAITTS` React hook for client-side TTS
- Add `createCambAIAudioSpeech` server helper for backend TTS
- 12 built-in CAMB AI voices with `voiceList` and `getCambAIVoiceOptions`
- Configurable output format (`mp3`, `wav`, `raw`) — defaults to `mp3`
- Barrel exports from `@lobehub/tts`, `@lobehub/tts/react`, and `@lobehub/tts/server`
- Fix vitest `@` alias to use `resolve()` for correct path resolution
- 30 tests covering constructor, fetch, create, voice list, format config, and server helper

## Summary by Sourcery

Add support for the CAMB AI text-to-speech provider across core, React, and server modules, including configuration, voice presets, and server helpers, with accompanying tests and config updates.

New Features:
- Introduce CambAITTS core client with configurable API key, proxy URL, service URL, voice presets, and audio output formats.
- Add a React useCambAITTS hook for client-side TTS integration using the CambAITTS provider.
- Provide a createCambAIAudioSpeech server helper for performing CAMB AI TTS requests on the backend.
- Expose CAMBAI API constants and CambAITTS-related types and utilities through existing barrel exports.

Bug Fixes:
- Correct Vitest path alias configuration to use resolved absolute src paths for the @ and package name aliases.

Tests:
- Add comprehensive tests covering CambAITTS construction, direct and serviceUrl fetch behavior, voice list and options, defaulting and configuration of formats and models, and the createCambAIAudioSpeech helper.